### PR TITLE
added node-lessify transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install --save yoyo-boostrap
  - Built with <a href="https://github.com/maxogden/yo-yo">yo-yo</a>, the lightest UI framework
  - Minimal dependencies (average `4.1kb` minified + g-zipped, usually just `yo-yo`)
  - Uses Bootstrap `3.3.6-stable` LESS
+ - Includes [node-lessify](https://www.npmjs.com/package/node-lessify) for [browserify](https://www.npmjs.com/package/browserify) bundling
  - ES6 import compatible (i.e. `import Alert, Button from 'yoyo-bootstrap'`)
 
 ## About

--- a/package.json
+++ b/package.json
@@ -22,11 +22,17 @@
   },
   "homepage": "https://github.com/silentcicero/yoyo-bootstrap#readme",
   "devDependencies": {
-    "bootstrap": "^3.3.6"
+    "bootstrap": "^3.3.6",
+    "node-lessify": "^0.1.4"
   },
   "dependencies": {
     "throw-down": "^0.1.2",
     "dom101": "^1.3.0",
     "yo-yo": "^1.1.1"
+  },
+  "browserify": {
+    "transform": [
+      "node-lessify"
+    ]
   }
 }


### PR DESCRIPTION
Added [node-lessify](https://www.npmjs.com/package/node-lessify) as a development dependency and included it as a [browserify](https://www.npmjs.com/package/browserify) transform in `package.json`. Dropped a note in README as well.
#### Why?

If using yoyo-bootstrap in your project and bundling it up with browserify, a transform is needed in order for the less files to be parsed correctly. Since browserify transforms are only applied to your own project and not its dependencies (discussion about that [here](https://github.com/KyleAMathews/react-spinkit/issues/9#issuecomment-77677951)), the less transform needs to be specified on yoyo-bootstrap itself.

Now we are able to take a project like this:

``` js
// app.js
const Button = require('yoyo-bootstrap/button')

document.body.appendChild(Button({
  bsStyle: 'primary',
  bsSize: 'medium'
}, 'Some Inner Content'))
```

And bundle it up for the browser using browserify...

```
browserify app.js > bundle.js
```

... with no parse errors! 🙃
